### PR TITLE
change help dialogue to close

### DIFF
--- a/webui/devtools.js
+++ b/webui/devtools.js
@@ -79,6 +79,12 @@ $(function (){
   $("#closehelp").click(function(){
     $("#help").hide();
   });
+  $(document).mouseup(function (e){
+    var container = $("#help");
+    if (!container.is(e.target) && container.has(e.target).length === 0){
+        container.hide();
+    }
+  })
 
   $("#reset").click(function(){
     if (window.confirm(i18n.t("confirm-reset"))) {

--- a/webui/devtools.js
+++ b/webui/devtools.js
@@ -84,7 +84,7 @@ $(function (){
     if (!container.is(e.target) && container.has(e.target).length === 0){
         container.hide();
     }
-  })
+  });
 
   $("#reset").click(function(){
     if (window.confirm(i18n.t("confirm-reset"))) {


### PR DESCRIPTION
A click that is not on the help dialogue will cause it to be hidden.
This fixes a small user experience paper-cut. 