### PR TITLE
Introduct ^ as shortcut for ↑ (NAND)

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
 	<td>∧</td>
         <td>∨</td>
         <td>→</td>
+        <td>↑</td>
         <td>¬</td>
         <td>∀</td>
         <td>∃</td>
@@ -424,6 +425,7 @@
 	<td>&amp;</td>
         <td>|</td>
         <td>-&gt;</td>
+        <td>^</td>
         <td>~</td>
         <td>!</td>
         <td>?</td>

--- a/logic/Propositions.hs
+++ b/logic/Propositions.hs
@@ -128,7 +128,7 @@ termP :: Parser Proposition
 termP =  buildExpressionParser table atomP <?> "proposition"
 
 table :: OperatorTable String () Identity Proposition
-table = [ [ binary "↑" [] AssocLeft
+table = [ [ binary "↑" ["^"] AssocLeft
           ]
         , [ binary "∧" ["&"] AssocLeft
           ]


### PR DESCRIPTION
Introduce a shortcut for Nand as requested in #48. Not sure if there's other plans to use `^` yet, so feel free to comment! We could use `Nand` (like we do for bottom with `False`) instead to keep the ASCII free for future use.