### PR TITLE
implement remove custom task

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,43 @@
             #customtask button {
                 width: 100%;
             }
+            #customtasks.tasklist .tool-remove {
+               position: relative;
+               top: -20px;
+               left: 150px;
+               width: 0px;
+               height: 0px;
+               opacity: 0;
+               cursor: pointer;
+            }
+            #customtasks.tasklist:hover .tool-remove {
+               opacity: 1;
+            }
+            
+            #customtasks.tasklist .tool-remove circle {
+                fill: white;
+                stroke: #ccc;
+                stroke-width: 1px;
+                stroke-opacity: .5;
+            }
+            
+            #customtasks.tasklist .tool-remove:hover circle {
+                fill: #e74c3c;
+                stroke: #c0392b;
+            }
+            
+            #customtasks.tasklist .tool-remove path {
+                fill: white;
+                stroke: #ccc;
+            }
+            
+            #customtasks.tasklist .tool-remove circle {
+                transition: fill 1s;
+            }
+            
+            #customtasks.tasklist .tool-remove:hover path {
+                stroke: none;
+            }
 
             #horizpane {
                 flex-grow: 1;

--- a/webui/task-management.js
+++ b/webui/task-management.js
@@ -71,7 +71,7 @@ function taskToHTML(task, canRemove, idx) {
     d2.append($("<li>").text(incredibleFormatTerm(el)));
   });
   if (!!canRemove) {
-    var tool = $('<div class="tool-remove"><svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" transfomr="translate(50,-17.5)"></div>');
+    var tool = $('<div class="tool-remove"><svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px"></div>');
     var svg = V(tool.find("svg").get(0));
     var markup = ['<g transform="translate(16,16)">',
         '<circle r="11" />',


### PR DESCRIPTION
still a bit messy... Is there a way to delegate events to the child (remove-tool) only and not to the surrounding `<div>`? Such that the `evt.target == this` can be omitted in the click handler.