### PR TITLE
Add proofs for quantifier identities

### DIFF
--- a/sessions.yaml
+++ b/sessions.yaml
@@ -207,6 +207,10 @@
     conclusions: ["∃y.∃x.P(x,y)"]
   - assumptions: ["∃x.∀y.P(x,y)"]
     conclusions: ["∀y.∃x.P(x,y)"]
+  - assumptions: ["∀x.P(x)"]
+    conclusions: ["(∃x.P(x)→⊥)→⊥"]
+  - assumptions: ["(∀x.P(x))→⊥"]
+    conclusions: ["∃x.P(x)→⊥"]
   - assumptions: ["(∀x.P(x))→A"]
     conclusions: ["∃x.P(x)→A"]
 - name: Session 7


### PR DESCRIPTION
I think these are good practice before tackling the final proof of Session 6. Plus the second one can be used in the final proof.

Note: I haven't built locally yet to test that I don't have a typo. I'll do as soon as I can. I have some environment setup I need to do before I can build. Notably I don't have ghcjs installed.