### PR TITLE
bump more block counts

### DIFF
--- a/sessions.yaml
+++ b/sessions.yaml
@@ -306,29 +306,34 @@
   - conclusions: ["(A→B→C)→B→A→C"]
     min-blocks: 20
   - conclusions: ["~A→A→B"]
-    min-blocks: 12
+    min-blocks: 8
   - conclusions: ["(~A→A)→A"]
-    min-blocks: 32
+    min-blocks: 20
   - conclusions: ["~~A→A"]
-    min-blocks: 30
+    min-blocks: 18
   - conclusions: ["A→~~A"]
-    min-blocks: 32
+    min-blocks: 20
   - conclusions: ["(B→A)→~A→~B"]
-    min-blocks: 116
+    min-blocks: 60
   - conclusions: ["(A→B)→(~A→B)→B"]
-    min-blocks: 200
+    min-blocks: 82
 - name: NAND calculus
   logic: nand
   tasks:
   - assumptions: ["A↑B"]
     conclusions: ["B↑A"]
+    min-blocks: 4
   - assumptions: ["A"]
     conclusions: ["(A↑A)↑(A↑A)"]
+    min-blocks: 4
   - conclusions: ["A↑A↑A"]
+    min-blocks: 2
   - assumptions: ["(A↑A)↑(A↑A)"]
     conclusions: ["A"]
+    min-blocks: 6
   - assumptions: ["A","B"]
     conclusions: ["A↑B↑(A↑B)"]
+    min-blocks: 6
   - assumptions: ["A↑B↑(A↑B)"]
     conclusions: ["A","B"]
 - name: Simply type lambda calculus


### PR DESCRIPTION
See https://github.com/nomeata/incredible/pull/101#issuecomment-453893190 and following posts for details. (haven't got the last NAND, but am pretty sure the others are optimal.)

The last problem, with the inner structure of all custom blocks involved:
![image](https://user-images.githubusercontent.com/3064145/51309598-ccd8bb00-1a12-11e9-9c77-a40fbca3d71f.png)
<details>

![image](https://user-images.githubusercontent.com/3064145/51309611-d19d6f00-1a12-11e9-9d78-cf1cffa1c55e.png)
![image](https://user-images.githubusercontent.com/3064145/51309615-d4985f80-1a12-11e9-8c71-0a62872101e7.png)
![image](https://user-images.githubusercontent.com/3064145/51309621-d6fab980-1a12-11e9-9911-8ace2277009a.png)
![image](https://user-images.githubusercontent.com/3064145/51309625-d95d1380-1a12-11e9-9902-2268ff07b3a6.png)
</details>